### PR TITLE
Cleanup and fix windows handle leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,28 @@
 [package]
 name = "read-process-memory"
-version = "0.1.4-pre"
+edition = "2021"
+version = "0.2.0-pre"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 description = "Read memory from another process."
 homepage = "https://github.com/rbspy/read-process-memory"
 repository = "https://github.com/rbspy/read-process-memory"
+rust-version = "1.56"
 
 [dependencies]
-libc = "0.2.15"
-log = "0.4.6"
+libc = "0.2"
+log = "0.4"
 
 [target.'cfg(target_os="macos")'.dependencies]
-mach = "0.0.5"
+mach = "0.3.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
-
-[dev-dependencies]
-docmatic = "0.1"
+winapi = { version = "0.3", features = [
+  "std",
+  "basetsd",
+  "minwindef",
+  "handleapi",
+  "memoryapi",
+  "processthreadsapi",
+  "winnt",
+] }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ A crate to read memory from another process. Code originally taken from the [rbs
 This example re-executes itself as a child process in order to have a separate process to use for demonstration purposes. If you need to read memory from a process that you are spawning, your usage should look very similar to this:
 
 ```rust
-extern crate read_process_memory;
-
 use std::convert::TryInto;
 use std::env;
 use std::io::{self, BufReader, BufRead, Read, Result};

--- a/examples/read-process-bytes.rs
+++ b/examples/read-process-bytes.rs
@@ -6,9 +6,7 @@ use std::convert::TryInto;
 use std::env;
 
 fn bytes_to_hex(bytes: &[u8]) -> String {
-    let hex_bytes: Vec<String> = bytes.iter()
-        .map(|b| format!("{:02x}", b))
-        .collect();
+    let hex_bytes: Vec<String> = bytes.iter().map(|b| format!("{:02x}", b)).collect();
     hex_bytes.join("")
 }
 
@@ -23,12 +21,14 @@ fn main() {
             e
         })
         .map(|bytes| {
-            println!("{} bytes at address {:x}:
+            println!(
+                "{} bytes at address {:x}:
 {}
 ",
-                     size,
-                     addr,
-                     bytes_to_hex(&bytes))
+                size,
+                addr,
+                bytes_to_hex(&bytes)
+            )
         })
         .unwrap();
 }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -3,11 +3,16 @@ use std::env;
 use std::io::{self, Read};
 
 fn main() {
-    let size = env::args().nth(1).and_then(|a| a.parse::<usize>().ok()).unwrap_or(32);
+    let size = env::args()
+        .nth(1)
+        .and_then(|a| a.parse::<usize>().ok())
+        .unwrap_or(32);
     let data = if size <= u8::max_value() as usize {
         (0..size as u8).collect::<Vec<u8>>()
     } else {
-        (0..size).map(|v| (v % (u8::max_value() as usize + 1)) as u8).collect::<Vec<u8>>()
+        (0..size)
+            .map(|v| (v % (u8::max_value() as usize + 1)) as u8)
+            .collect::<Vec<u8>>()
     };
     println!("{:p} {}", data.as_ptr(), data.len());
     // Wait to exit until stdin is closed.

--- a/tests/readme_test.rs
+++ b/tests/readme_test.rs
@@ -1,6 +1,0 @@
-extern crate docmatic;
-
-#[test]
-fn test_readme() {
-    docmatic::assert_file("README.md");
-}


### PR DESCRIPTION
To fix #14 we have to add a `Drop` impl for the windows `ProcessHandle`. This also means that we need to remove the `Copy` and `Clone` impls for that struct to avoid closing the handle while a copy is still held.

It seems unfortunate to have all the other platforms impl copy/clone for the handle and for windows to have neither. I think the best middle ground would be to remove `Copy` across the board, and then make the windows `ProcessHandle` use an `Arc` internally so it can still impl `Clone`, but if we're fine with the asymmetry between platforms we can leave it as is.

I also took the liberty of updating the edition from 2015 to 2021, running rustfmt, and updating the dependencies. `winapi` has subsumed the old `kernel32` crate, so I removed the latter. If these cleanup changes aren't wanted I can revert them and just include the bug fix.

Fixes #14