### PR TITLE
Implement Deref for ProcessHandle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,7 @@ mod platform {
     use std::convert::TryFrom;
     use std::io;
     use std::mem;
+    use std::ops::Deref;
     use std::os::windows::io::{AsRawHandle, RawHandle};
     use std::process::Child;
     use std::ptr;
@@ -397,6 +398,14 @@ mod platform {
     /// On Windows a `ProcessHandle` is a `HANDLE`.
     #[derive(Clone, Eq, PartialEq, Hash)]
     pub struct ProcessHandle(Arc<ProcessHandleInner>);
+
+    impl Deref for ProcessHandle {
+        type Target = RawHandle;
+    
+        fn deref(&self) -> &Self::Target {
+            &self.0.0
+        }
+    }
 
     impl Drop for ProcessHandleInner {
         fn drop(&mut self) {


### PR DESCRIPTION
This ensures that crates like remoteprocess can still use the underlying handle now that it's a private part of the API.

Note that this is based on a copy of the branch from #16 to keep the diff clean.