### PR TITLE
Improvements for macOS

### DIFF
--- a/examples/read-self.rs
+++ b/examples/read-self.rs
@@ -1,0 +1,20 @@
+/// Read bytes from the current process.
+use read_process_memory::*;
+use std::convert::TryInto;
+
+fn main() {
+    let data = vec![17u8, 23u8, 45u8, 0u8];
+    let pid = unsafe { libc::getpid() } as Pid;
+    let addr = data.as_ptr() as usize;
+    let handle: ProcessHandle = pid.try_into().unwrap();
+    copy_address(addr, 4, &handle)
+        .map_err(|e| {
+            println!("Error: {:?}", e);
+            e
+        })
+        .map(|bytes| {
+            assert_eq!(bytes, vec![17u8, 23u8, 45u8, 0u8]);
+            println!("Success!")
+        })
+        .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,11 +234,14 @@ mod platform {
             };
 
             if read_len != buf.len() as vm_size_t {
-                panic!(
-                    "Mismatched read sizes for `vm_read` (expected {}, got {})",
-                    buf.len(),
-                    read_len
-                )
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "Mismatched read sizes for `vm_read` (expected {}, got {})",
+                        buf.len(),
+                        read_len
+                    ),
+                ));
             }
 
             if result != KERN_SUCCESS {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,8 +544,9 @@ mod test {
 
     #[test]
     fn test_read_large() {
-        // 5000 should be greater than a single page on most systems.
-        const SIZE: usize = 5000;
+        // 20,000 should be greater than a single page on most systems.
+        // macOS on ARM is 16384.
+        const SIZE: usize = 20_000;
         let arg = format!("{}", SIZE);
         let mem = read_test_process(Some(&[&arg])).unwrap();
         let expected = (0..SIZE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,9 +406,9 @@ mod platform {
 
     impl Deref for ProcessHandle {
         type Target = RawHandle;
-    
+
         fn deref(&self) -> &Self::Target {
-            &self.0.0
+            &self.0 .0
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@ pub use crate::platform::Pid;
 /// ```
 ///
 /// This operation is not guaranteed to succeed. Specifically, on Windows
-/// `OpenProcess` may fail, and on macOS `task_for_pid` will generally fail
+/// `OpenProcess` may fail. On macOS `task_for_pid` will generally fail
 /// unless run as root, and even then it may fail when called on certain
-/// programs.
+/// programs; it may however run without root on the current process.
 pub use crate::platform::ProcessHandle;
 
 #[cfg(target_os = "linux")]
@@ -165,8 +165,8 @@ mod platform {
     /// A small wrapper around `task_for_pid`, which takes a pid and returns the
     /// mach port representing its task.
     fn task_for_pid(pid: Pid) -> io::Result<mach_port_name_t> {
-        if pid == libc::getpid() as Pid {
-            return Ok(mach::traps::mach_task_self());
+        if pid == unsafe { libc::getpid() } as Pid {
+            return Ok(unsafe { mach::traps::mach_task_self() });
         }
 
         let mut task: mach_port_name_t = MACH_PORT_NULL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,10 @@ mod platform {
     /// A small wrapper around `task_for_pid`, which takes a pid and returns the
     /// mach port representing its task.
     fn task_for_pid(pid: Pid) -> io::Result<mach_port_name_t> {
+        if pid == libc::getpid() as Pid {
+            return Ok(mach::traps::mach_task_self());
+        }
+
         let mut task: mach_port_name_t = MACH_PORT_NULL;
 
         unsafe {


### PR DESCRIPTION
1. Improve testing: pages can be more than 4kb.
2. Add an example of reading from current process.
3. Making reading from current process bypass `task_for_pid()`, since we don't need it and it increases the chance of requiring root.
4. Get rid of a panic because panics are a problematic way to return errors.